### PR TITLE
Fix PowerShell window on export

### DIFF
--- a/DriverImportTool.py
+++ b/DriverImportTool.py
@@ -35,8 +35,21 @@ def log_message(log_path, message, console=None):
         print(f"{timestamp} {message}")
 
 def run_command(command, log_path, console=None):
-    process = subprocess.Popen(["powershell", "-Command", command],
-                               stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+    creationflags = 0
+    if os.name == "nt":
+        creationflags = subprocess.CREATE_NO_WINDOW
+
+    process = subprocess.Popen([
+            "powershell",
+            "-NoProfile",
+            "-Command",
+            command
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        creationflags=creationflags
+    )
     for line in process.stdout:
         log_message(log_path, line.strip(), console)
     process.wait()


### PR DESCRIPTION
## Summary
- hide spawned PowerShell window and capture output when running export/import

## Testing
- `python -m py_compile DriverImportTool.py`


------
https://chatgpt.com/codex/tasks/task_e_688bf33a315883219fab290b79c86f08