### PR TITLE
Improve permissions error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ For scripting or remote execution, run with the `-console` flag:
 DriverImportTool.exe -console -import "C:\Drivers\LenovoM74"
 DriverImportTool.exe -console -export "C:\Drivers\HPEliteDesk"
 DriverImportTool.exe -console -import "C:\Drivers\Dell" -logFilePath "D:\Logs\CustomImportLog.log"
+DriverImportTool.exe -console -export "C:\Drivers\HP" -nolog
 ```
 
 If `-logFilePath` is omitted, logs are saved to:
@@ -45,6 +46,7 @@ If `-logFilePath` is omitted, logs are saved to:
 ```
 C:\DriverImporter-{PCNAME}.log
 ```
+Use `-nolog` to skip creating a log file.
 
 ---
 


### PR DESCRIPTION
## Summary
- handle permission errors when writing the log file
- ensure import/export tasks report exceptions in GUI
- catch failures in console mode
- disable logging with a checkbox or `-nolog` flag
- pre-check log file creation and warn if not writable

## Testing
- `python -m py_compile DriverImportTool.py`
- `python DriverImportTool.py -console`


------
https://chatgpt.com/codex/tasks/task_e_688c6e6d5f188321b24a80500ec4d6d3