### PR TITLE
Enable console mode without blank window

### DIFF
--- a/DriverImportTool.py
+++ b/DriverImportTool.py
@@ -7,6 +7,7 @@ import socket
 import time
 import ctypes
 import argparse
+import sys
 from datetime import datetime
 from pathlib import Path
 import tkinter as tk
@@ -364,6 +365,15 @@ Admin rights are required for full functionality.
 
 # --- CLI ---
 def start_console():
+    if os.name == "nt":
+        try:
+            # Attach to parent console if possible, otherwise create a new one
+            if ctypes.windll.kernel32.AttachConsole(-1) == 0:
+                ctypes.windll.kernel32.AllocConsole()
+            sys.stdout = open("CONOUT$", "w")
+            sys.stderr = open("CONOUT$", "w")
+        except Exception:
+            pass
     parser = argparse.ArgumentParser()
     parser.add_argument("-console", action="store_true")
     parser.add_argument("-import", dest="import_path", type=str, help="Path to import drivers from")
@@ -391,7 +401,6 @@ def start_console():
 
 # --- Entry Point ---
 if __name__ == "__main__":
-    import sys
     if "-console" in sys.argv:
         start_console()
     else:

--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ To package into a `.exe`:
 pyinstaller --noconfirm --onefile --windowed DriverImportTool.py
 ```
 
-> To enable console output for console mode, remove `--windowed`
+Console mode now opens its own window when the `-console` flag is used, so you
+can keep the `--windowed` option.
 
 ---
 


### PR DESCRIPTION
## Summary
- allocate/attach console dynamically when `-console` is used
- keep GUI window hidden when running in GUI mode
- clarify PyInstaller instructions for console mode

## Testing
- `python DriverImportTool.py -console -h`
- `python DriverImportTool.py -console -import /tmp`
- `python -m py_compile DriverImportTool.py`

------
https://chatgpt.com/codex/tasks/task_e_688ca40a5f0c8321900df711cb1de5f9