### PR TITLE
Add model-aware import and display

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ DriverImportTool.exe -console -import "C:\Drivers\LenovoM74"
 DriverImportTool.exe -console -export "C:\Drivers\HPEliteDesk"
 DriverImportTool.exe -console -import "C:\Drivers\Dell" -logFilePath "D:\Logs\CustomImportLog.log"
 DriverImportTool.exe -console -export "C:\Drivers\HP" -nolog
+DriverImportTool.exe -console -importAuto "\\10.20.8.226\Drivers$"
 ```
 
 If `-logFilePath` is omitted, logs are saved to:


### PR DESCRIPTION
## Summary
- display computer name and model at top of GUI
- add PC model detection
- add `-importAuto` console switch that appends model folder
- document new switch in README

## Testing
- `python -m py_compile DriverManagementTool.py`

------
https://chatgpt.com/codex/tasks/task_e_688caecfa8a483218695b7495ffa1ba4